### PR TITLE
Return only the Specified path's mountpoint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -499,11 +499,14 @@ pub fn get_mountpoint(device: &Path) -> BlockResult<Option<PathBuf>> {
     for line in reader.lines() {
         let l = line?;
         let parts: Vec<&str> = l.split_whitespace().collect();
-        let parts_cpy = parts.clone();
-        for p in parts_cpy {
+        let mut index = -1;
+        for (i, p) in parts.iter().enumerate() {
             if p == &s {
-                return Ok(Some(PathBuf::from(parts[1])));
+                index = i as i64;
             }
+        }
+        if index >= 0 {
+            return Ok(Some(PathBuf::from(parts[1])));
         }
     }
     Ok(None)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ impl err for BlockUtilsError {
             BlockUtilsError::UdevError(ref e) => e.description(),
         }
     }
-    fn source(&self) -> Option<&(dyn err + 'static)>{
+    fn source(&self) -> Option<&(dyn err + 'static)> {
         match *self {
             BlockUtilsError::Error(_) => None,
             BlockUtilsError::IoError(ref e) => e.source(),
@@ -498,9 +498,10 @@ pub fn get_mountpoint(device: &Path) -> BlockResult<Option<PathBuf>> {
 
     for line in reader.lines() {
         let l = line?;
-        if l.contains(&s) {
-            let parts: Vec<&str> = l.split_whitespace().collect();
-            if !parts.is_empty() {
+        let parts: Vec<&str> = l.split_whitespace().collect();
+        let parts_cpy = parts.clone();
+        for p in parts_cpy {
+            if p == &s {
                 return Ok(Some(PathBuf::from(parts[1])));
             }
         }


### PR DESCRIPTION
Changed get_mountpoint so only the specific device path is searched for in /etc/mtab.  Disks will no longer have the mountpoint of one of its partitions returned.  

Before, if input was /dev/sdX (with no mountpoint), however /dev/sdX# had a mountpoint, that mountpoint was returned

Now, only /dev/sdX will only have a mountpoint returned if it is mounted.  