### PR TITLE
Update `udev` to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ serde_json = "~1.0"
 uuid = "~0.8"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-udev = "~0.4"
+udev = "~0.5"


### PR DESCRIPTION
The 0.5 line includes an important fix Smithay/udev-rs#18.  Without this fix, certain udev operations, including device enumeration, will crash with a segfault on systems using an older version of `libudev`.  The full list of distros impacted by this bug is unknown, but I was able to reproduce it consistently with Debian 8.

Please note that the fix to this issue is an API breaking change.  I don't think it impacts this project but you probably shouldn't take my word for it.
