### PR TITLE
Extend FilesystemType enum to support windows filesystems

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -356,6 +356,12 @@ pub enum FilesystemType {
     Lvm,
     Xfs,
     Zfs,
+    Ntfs,
+    /// All FAT-based filesystems, i.e. VFat, Fat16, Fat32, Fat64, ExFat.
+    Vfat,
+    /// Unknown filesystem with label (name).
+    Unrecognised(String),
+    /// Unknown filesystem without label (name) or absent filesystem.
     Unknown,
 }
 
@@ -372,7 +378,10 @@ impl FromStr for FilesystemType {
             "lvm2_member" => Ok(FilesystemType::Lvm),
             "xfs" => Ok(FilesystemType::Xfs),
             "zfs" => Ok(FilesystemType::Zfs),
-            _ => Ok(FilesystemType::Unknown),
+            "vfat" => Ok(FilesystemType::Vfat),
+            "ntfs" => Ok(FilesystemType::Ntfs),
+            "" => Ok(FilesystemType::Unknown),
+            name => Ok(FilesystemType::Unrecognised(name.to_string()))
         }
     }
 }
@@ -387,6 +396,9 @@ impl FilesystemType {
             FilesystemType::Lvm => "lvm",
             FilesystemType::Xfs => "xfs",
             FilesystemType::Zfs => "zfs",
+            FilesystemType::Vfat => "vfat",
+            FilesystemType::Ntfs => "ntfs",
+            FilesystemType::Unrecognised(ref name) => name.as_str(),
             FilesystemType::Unknown => "unknown",
         }
     }
@@ -402,6 +414,9 @@ impl fmt::Display for FilesystemType {
             FilesystemType::Lvm => "lvm".to_string(),
             FilesystemType::Xfs => "xfs".to_string(),
             FilesystemType::Zfs => "zfs".to_string(),
+            FilesystemType::Vfat => "vfat".to_string(),
+            FilesystemType::Ntfs => "ntfs".to_string(),
+            FilesystemType::Unrecognised(ref name) => name.clone(),
             FilesystemType::Unknown => "unknown".to_string(),
         };
         write!(f, "{}", string)


### PR DESCRIPTION
 - Add variant for windows filesystems `Ntfs` and `Vfat` (which is a common label for all FAT* filesystems)
 - Add variant for unrecognized fs which contains its label (name).
 - Keep Unknown variant without changes for backward-compatibility. Unknown means the filesystem without known label (name) or absent filesystem.
 
 Note: 
 1. I haven't added the ReFS support, because I can't test how it's described on the Linux in udev or fstab. I'm not sure the ReFS is supported by Linux at all. However, if so, now we can recognize it manually using content of `Unrecognised(String)` variant.
 2. All FAT* filesystems describes in udev and fstab as `vfat`. The recognizing of specific type(version) of FAT is possible (at least with udev) but it requires a deeper investigation while this PR is more like a kind of hotfix.
 3. I've tested it locally at my Ubuntu 20.20 and I hope it works in the same way on the other distros.
 4. I'm going to use `strum` macro to avoid a boilerplate here, but not right now (see #26).

 If you have any objections about usage of `Unrecognised(String)` / `Unknown` please let me know. 
 
 Close #25 