### PR TITLE
Avoid the boilerplate in enums with strum 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = "~1.0"
 uuid = "~0.8"
 strum = "0.20"
 strum_macros = "0.20"
+thiserror = "1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 udev = "~0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ regex = "~1.4"
 shellscript = "~0.3"
 serde_json = "~1.0"
 uuid = "~0.8"
+strum = "0.20"
+strum_macros = "0.20"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 udev = "~0.5"


### PR DESCRIPTION
The goal of this PR is refactoring to avoid boilerplate in enums implementation.
 
First commit: Use `strum` crate for enums

Changes:

- Replace explicit `impl Display` with `strum::Display`
- Replace explicit `impl FromStr` with `strum::EnumString`
- Replace explicit `impl From<Enum> for &'static str` with `strum::IntoStaticStr`
- Add new error variant for `strum::ParseError`
- Replace explicit impl Default with derive

Changes in public interface:
- Now the error type of `FromStr` is `strum::ParseError` instead of `BlockUtilsError(String)`. The reason is current limitation in `strum`, see https://github.com/Peternator7/strum/issues/91
- The `Display` string for `DeviceState::FailFast` is "failfast" instead of "fail_fast", the same as its value for parsing in FromStr. If it's not acceptable, please let me know and I will come back the explicit implementation.

Note: 
- Unfortunately, I've overestimated the power of the `strum` crate. It has a lot of limitations (at least for now), therefore I've kept explicit impls in some cases. 
-  Strum can't handle correctly a case with default variant in Display and ToStr, like FilesystemType::Unrecognised(String). See https://github.com/Peternator7/strum/issues/86
- It seems I can't specify different attributes for serialization and deserializaition like "failfast" and "fail_fast" for DeviceState::FailFast, despite I don't see the issue for it.

Second commit: Use `thiserror` crate for errors
Changes: 
- Use derives of `thiserror` to avoid explicit `impl Error`, `impl Display`, `impl From<OtherError>` and so on.
- This change also allows to use `strum` for a bit more enums

This commit is not in the scope of initial issue, so I will revert it if you want.


Checks:
1. Current tests are Ok (but seems they don't use the changed functionality)
2. I've manually checked the accuracy of changes in terms of the same strings before and after these changes.
3. I use the fork with these changes in our project, and its tests are passed
If you think that this PR can't be merged without adding new tests let me know.

Also it would be great to release a new version of `block-utils` after merging this PR due to changes in #25 




Close #26 