### PR TITLE
Upgrade `strum` to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ regex = "1.5"
 shellscript = "0.3"
 serde_json = "1.0"
 uuid = "0.8"
-strum = "0.22"
-strum_macros = "0.22"
+strum = { version = "0.23", features = ["derive"] }
 thiserror = "1.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Output};
 use std::str::{from_utf8, FromStr};
-use strum_macros::{Display, EnumString, IntoStaticStr};
+use strum::{Display, EnumString, IntoStaticStr};
 use thiserror::Error;
 use uuid::Uuid;
 


### PR DESCRIPTION
This appeared on our `cargo-deny` radar. Would be glad if you could do a patch release. 

Even though "technically" `strum::ParseError` is part of public `BlockUtilsError` and `0.22 -> 0.23` is a breaking change, I doubt that anyone would break as a result of this, and if it would break, the resolution of the problem would not be too dificult