### PR TITLE
Fix get_mount_device function for root path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,9 +431,9 @@ pub fn get_mount_device(mount_dir: impl AsRef<Path>) -> BlockResult<Option<PathB
     let reader = BufReader::new(f);
 
     for line in reader.lines() {
-        let l = line?;
-        if l.contains(&dir) {
-            let parts: Vec<&str> = l.split_whitespace().collect();
+        let line = line?;
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.contains(&dir.as_str()) {
             if !parts.is_empty() {
                 return Ok(Some(PathBuf::from(parts[0])));
             }


### PR DESCRIPTION
If we pass `/` path to`get_mount_device` function it will return incorrect device. This happens because we check if entire line from `MTAB_PATH` contains given path. This work fine for long paths but fails if paths is `/` because any path contains `/` and this function will always return first line from `MTAB_PATH`. Fixed by splitting line before check.