### PR TITLE
updated uuid to version 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ nom = "5.1.1"
 regex = "1.5.5"
 shellscript = "0.3"
 serde_json = "1.0"
-uuid = "0.8"
+uuid = "1"
 strum = { version = "0.23", features = ["derive"] }
 thiserror = "1.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,7 +404,7 @@ pub fn mount_device(device: &Device, mount_point: impl AsRef<Path>) -> BlockResu
     match device.id {
         Some(id) => {
             arg_list.push("-U".to_string());
-            arg_list.push(id.to_hyphenated().to_string());
+            arg_list.push(id.as_hyphenated().to_string());
         }
         None => {
             arg_list.push(format!("/dev/{}", device.name));


### PR DESCRIPTION
Tested on:
```
$ rustc --version
rustc 1.60.0 (7737e0b5c 2022-04-04)
$ dpkg -s libudev-dev | grep '^Version:'
Version: 247.3-7
```