### PR TITLE
fix `list_nvme_devices()` - return a detailed struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ fstab = "0.4"
 log = "0.4"
 regex = "1.7"
 shellscript = "0.3"
+serde = { "version" = "1.0", features = ["derive"] }
 serde_json = "1.0"
 strum = { version = "0.23", features = ["derive"] }
 thiserror = "1.0"


### PR DESCRIPTION
Neither debian, ubuntu, nor alpine seem to have a `nvme-list` command. The `nvme` command provides a list subcommand that can be used for this.

If this is accepted I shall apply the same treatment to `list_nvme_controllers()`.