### PR TITLE
fix return of get_*_log functions in nvme module - issue 42

### DIFF
--- a/src/nvme.rs
+++ b/src/nvme.rs
@@ -27,7 +27,7 @@ struct NvmeDeviceContainer {
 }
 
 /// Retrieve the error logs from the nvme device
-pub fn get_error_log(dev: &Path) -> BlockResult<String> {
+pub fn get_error_log(dev: &Path) -> BlockResult<serde_json::Value> {
     let out = Command::new("nvme")
         .args(&["error-log", &dev.to_string_lossy(), "-o", "json"])
         .output()?;
@@ -37,12 +37,12 @@ pub fn get_error_log(dev: &Path) -> BlockResult<String> {
         ));
     }
     let stdout = String::from_utf8_lossy(&out.stdout);
-    let deserialized: String = serde_json::from_str(&stdout)?;
+    let deserialized: serde_json::Value = serde_json::from_str(&stdout)?;
     Ok(deserialized)
 }
 
 /// Retrieve the firmware logs from the nvme device
-pub fn get_firmware_log(dev: &Path) -> BlockResult<String> {
+pub fn get_firmware_log(dev: &Path) -> BlockResult<serde_json::Value> {
     let out = Command::new("nvme")
         .args(&["fw-log", &dev.to_string_lossy(), "-o", "json"])
         .output()?;
@@ -52,12 +52,12 @@ pub fn get_firmware_log(dev: &Path) -> BlockResult<String> {
         ));
     }
     let stdout = String::from_utf8_lossy(&out.stdout);
-    let deserialized: String = serde_json::from_str(&stdout)?;
+    let deserialized: serde_json::Value = serde_json::from_str(&stdout)?;
     Ok(deserialized)
 }
 
 /// Retrieve the smart logs from the nvme device
-pub fn get_smart_log(dev: &Path) -> BlockResult<String> {
+pub fn get_smart_log(dev: &Path) -> BlockResult<serde_json::Value> {
     let out = Command::new("nvme")
         .args(&["smart-log", &dev.to_string_lossy(), "-o", "json"])
         .output()?;
@@ -67,7 +67,7 @@ pub fn get_smart_log(dev: &Path) -> BlockResult<String> {
         ));
     }
     let stdout = String::from_utf8_lossy(&out.stdout);
-    let deserialized: String = serde_json::from_str(&stdout)?;
+    let deserialized: serde_json::Value = serde_json::from_str(&stdout)?;
     Ok(deserialized)
 }
 


### PR DESCRIPTION
Fixes issue #42.

Changed the return of functions `get_error_log()`, `get_firmware_log()` and `get_smart_log()` to `serde_json::Value`.

In addition to correcting the mismatched return type error (`Map` isn't a `String`), the user will be able to call something like this:
```
let log = get_firmware_log(&device_path).expect("error getting log");
println!("temp: {:.2} ºC", log.get("temperature").and_then(Value::as_f64).unwrap_or_default() - 273.15);
```