### PR TITLE
Add Additional MediaType and DeviceType variants; upgrade nix and strum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "block-utils"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["Chris Holcombe <xfactor973@gmail.com>"]
 description = "Utilities to work with block devices.  Formatting, getting device info, identifying type of device, etc."
-edition = '2018'
+edition = "2021"
 
 # These URLs point to more information about the repository.
 documentation = "https://docs.rs/block-utils"
@@ -13,7 +13,7 @@ readme = "README.md"
 license = "MIT"
 
 [dev-dependencies]
-nix = "0.23"
+nix = "0.26"
 tempfile = "3"
 
 [dependencies]
@@ -23,7 +23,7 @@ regex = "1.7"
 shellscript = "0.3"
 serde = { "version" = "1.0", features = ["derive"] }
 serde_json = "1.0"
-strum = { version = "0.24", features = ["derive"] }
+strum = { version = "0.25", features = ["derive"] }
 thiserror = "1.0"
 uuid = "1.3"
 


### PR DESCRIPTION
* `Vendor` can now `Display`
* Rename `Vendor:Vbox` to `Vendor::VirtualBox`
* Rename `Vendor::None` to `Vendor::ATA` to match its vendor string
* Make `Device::vendor` an `Option` that defaults to `Option::None` instead of `Vendor::None` when vendor is unknown
* Add `MediaType::Optical` for when a CD or DVD drive (or a virtual variant of the same) is detected
* Add `MediaType::Partitions` to represent detection of a partition table on a device
* Add `MediaType::Partition` to represent when a device represents a partition
* Rename `MediaType::Virtual` to `MediaType::Qemu` to distinguish it from Virtual Box media
* Add `MediaType::VirtualBox`
* Add `MediaType::Unrecognised` with a field to expose the vendor of unrecognized media
* `MediaType` can now `Display`
* Add `DeviceType::Unrecognised` to expose the value of a device type that is not represented as an enum variant

`MediaType::Unknown` still exists but is now only used when the matching rules don't have any input to work with.

* Upgrade `nix` from 0.23 to 0.26. There is a newer version 0.27 but it has breaking changes.
* Upgrade `strum` from 0.24 to 0.25
* Update the `cargo edition` from 2018 to 2021

`udev` cannot be easily upgraded; there is a breaking change to `Enumerator` ownership related `scan_devices` which will require a significant refactor to some of the `_iter` functions.

Lastly I bumped the crate version from `0.11` to `0.12.0` to represent that this is a breaking change. [edited this comment to reflect your feedback]